### PR TITLE
allow individual list item components to not be interactive

### DIFF
--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -17,22 +17,23 @@ export interface ListProps extends HTMLProps<HTMLUListElement> {
    */
   listSize?: ListSize;
   /**
-   * Whether or not the list is interactive (e.g. provide hover color)
-   * @default true
-   */
-  interactive?: boolean;
-  /**
    * Whether or not to strip the inner padding.
    * Useful for when the contents uses a link
    * @default false
    */
   noPadding?: boolean;
   children: ReactNode;
+  /**
+   * Whether or not the list is interactive (e.g. provide hover color)
+   * Note: child ListItem styles may clash if both interactive properties are provided
+   * @default false
+   */
+  interactive?: boolean;
 }
 export function List({
   children,
   listSize = 'default',
-  interactive = true,
+  interactive = false,
   noPadding = false,
 }: ListProps) {
   return (
@@ -41,12 +42,11 @@ export function List({
         list-style: none;
         padding: 0;
         margin: 0;
-        & > li:hover {
-          background-color: ${interactive
-            ? theme.colors.hoverBgColor
-            : 'transparent'};
-          cursor: ${interactive ? 'pointer' : 'default'};
-        }
+        ${interactive &&
+          `& > li:hover {
+          background-color: ${theme.colors.hoverBgColor};
+          cursor: pointer;
+        }`}
       `}
     >
       {Children.map(children, child => {
@@ -76,9 +76,19 @@ export interface ListItemProps extends HTMLProps<HTMLLIElement> {
   noPadding?: boolean;
   onClick?: (e: SyntheticEvent<HTMLLIElement>) => void;
   children: ReactNode;
+  /**
+   * Whether or not the list item is interactive (e.g. provide hover color)
+   * Note that parent List styles may clash if both interactive properties are provided
+   * @default true
+   */
+  interactive?: boolean;
 }
 
-const listItemCSS = (options: { noPadding: boolean; listSize?: ListSize }) => {
+const listItemCSS = (options: {
+  noPadding: boolean;
+  listSize?: ListSize;
+  interactive: boolean;
+}) => {
   const spacing =
     options.listSize === 'small'
       ? theme.spacing.padding8
@@ -87,6 +97,12 @@ const listItemCSS = (options: { noPadding: boolean; listSize?: ListSize }) => {
   return css`
     padding: ${innerPadding}px;
     position: relative;
+    &:hover {
+      background-color: ${options.interactive
+        ? theme.colors.hoverBgColor
+        : 'transparent'};
+      cursor: ${options.interactive ? 'pointer' : 'default'};
+    }
 
     &:not(:first-of-type)::after {
       content: ' ';
@@ -103,10 +119,14 @@ export function ListItem({
   children,
   listSize = 'default',
   noPadding = false,
+  interactive = true,
   onClick,
 }: ListItemProps) {
   return (
-    <li css={listItemCSS({ listSize, noPadding })} onClick={onClick}>
+    <li
+      css={listItemCSS({ listSize, noPadding, interactive })}
+      onClick={onClick}
+    >
       {children}
     </li>
   );

--- a/stories/List.stories.tsx
+++ b/stories/List.stories.tsx
@@ -76,6 +76,27 @@ const WithLinksTemplate: Story<ListProps> = args => (
   </Card>
 );
 
+const Interacting: Story<ListProps> = args => (
+  <Card title="Model Info" bodyStyle={{ padding: 0 }} style={{ width: 300 }}>
+    <List {...args}>
+      {Array.from('12345').map(num => (
+        <ListItem key={num} interactive={Number(num) % 2 === 0}>
+          <div
+            css={css`
+              display: flex;
+              flex-direction: column;
+            `}
+          >
+            <Text textSize="medium" weight="heavy">{`List Item ${num}`}</Text>
+            <Text textSize="small" color="white70">{`Subtext`}</Text>
+          </div>
+        </ListItem>
+      ))}
+    </List>
+  </Card>
+);
+
 // By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
 // https://storybook.js.org/docs/react/workflows/unit-testing
 export const WithLinks = WithLinksTemplate.bind({});
+export const WithDifferentInteractive = Interacting.bind({});


### PR DESCRIPTION
defaults parent interactive to false, and individual children to true so that it's easier to implement Disabled States. Kept parent interactive flag for ease of use for long lists & reducing redundancy

- if the parent list has interactive: true, all children elements will include interactive styling
- if the parent list has interactive: false, all children elements styles will be depending on their own interactive state
