### PR TITLE
Respect isDisabled on ActionMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/menu/ActionMenu.tsx
+++ b/src/menu/ActionMenu.tsx
@@ -64,6 +64,7 @@ function ActionMenu<T extends object>(
         children={buttonChildren}
         size={buttonSize}
         variant={buttonVariant}
+        disabled={props.isDisabled}
       />
       <Menu
         children={children}

--- a/stories/ActionMenu.stories.tsx
+++ b/stories/ActionMenu.stories.tsx
@@ -165,6 +165,21 @@ const Template: Story<DropdownProps> = args => (
           </Section>
         </ActionMenu>
       </div>
+      <div>
+        <Heading>Fully Disabled</Heading>
+        <ActionMenu icon={<Icon svg={<PlusCircleOutline />} />} isDisabled={true} buttonText={'Add Dashboard'}>
+          <Section title="File">
+            <Item key="new">
+              <Icon svg={<PlusCircleOutline />} />
+              New
+            </Item>
+            <Item key="open">
+              <Icon svg={<AlertTriangleFilled />} />
+              Triage
+            </Item>
+          </Section>
+        </ActionMenu>
+      </div>
     </div>
   </Provider>
 );


### PR DESCRIPTION
Allows ActionMenu to be fully disabled by passing `isDisabled` to the dropdown Button component
