### PR TITLE
fix: make placeholder text italic

### DIFF
--- a/src/picker/Picker.tsx
+++ b/src/picker/Picker.tsx
@@ -204,6 +204,7 @@ function Picker<T extends object>(
         .ac-dropdown-button__text {
           .is-placeholder {
             color: ${theme.textColors.white70};
+            font-style: italic;
           }
         }
       `}


### PR DESCRIPTION
Makes the placeholder text italic to delineate between real selection.