### PR TITLE
feat: allow overriding the selectedTab on Tabs component

### DIFF
--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -145,7 +145,7 @@ export function Tabs({
   const [selectedIndex, setSelectedIndex] = useControlledState(
     index,
     defaultValue,
-    () => {}
+    onChange
   );
   return (
     <div
@@ -168,7 +168,6 @@ export function Tabs({
               onClick={e => {
                 e.preventDefault();
                 setSelectedIndex(index);
-                onChange && onChange(index);
               }}
               {...tab?.tabListItemProps}
             >

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useState,
   Children,
   cloneElement,
   ReactNode,

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -112,6 +112,10 @@ function parseTabList(children: ReactNode): Tab[] {
 export type TabsProps = {
   children: ReactNode[];
   className?: string;
+  /**
+   * If specified, the index of the selected tab is controlled by the parent component rather than the internal state.
+   */
+  selectedTabIndex?: number;
   onChange?: (index: number) => void;
   /**
    * The orientation of the tabs. Defaults to horizontal
@@ -127,6 +131,7 @@ export type TabsProps = {
 export function Tabs({
   children,
   className,
+  selectedTabIndex,
   onChange,
   orientation = 'horizontal',
   extra,
@@ -135,9 +140,11 @@ export function Tabs({
   children = Children.toArray(children).filter(child => child);
   const tabs = parseTabList(children);
   // Initialize the selected tab to the first non-hidden tab
-  const [selectedIndex, setSelectedIndex] = useState<number>(
+  const [selectedStateIndex, setSelectedIndex] = useState<number>(
     tabs.findIndex(tab => !tab.hidden)
   );
+  const selectedIndex =
+    typeof selectedTabIndex == "number" ? selectedTabIndex : selectedStateIndex;
   return (
     <div
       className={`ac-tabs ${className}`}

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactElement,
   HtmlHTMLAttributes,
 } from 'react';
+import { useControlledState } from '@react-stately/utils';
 import { Text } from '../content';
 import { css } from '@emotion/react';
 import { Orientation } from '../types/orientation';
@@ -115,7 +116,7 @@ export type TabsProps = {
   /**
    * If specified, the index of the selected tab is controlled by the parent component rather than the internal state.
    */
-  selectedTabIndex?: number;
+  index?: number;
   onChange?: (index: number) => void;
   /**
    * The orientation of the tabs. Defaults to horizontal
@@ -131,7 +132,7 @@ export type TabsProps = {
 export function Tabs({
   children,
   className,
-  selectedTabIndex,
+  index,
   onChange,
   orientation = 'horizontal',
   extra,
@@ -139,12 +140,14 @@ export function Tabs({
   // Filter out the nulls from the children so that tabs can be mounted conditionally
   children = Children.toArray(children).filter(child => child);
   const tabs = parseTabList(children);
-  // Initialize the selected tab to the first non-hidden tab
-  const [selectedStateIndex, setSelectedIndex] = useState<number>(
-    tabs.findIndex(tab => !tab.hidden)
+  
+  // Initialize the selected tab to the first non-hidden tab if there is no controlled value provided
+  const defaultValue = tabs.findIndex(tab => !tab.hidden);
+  const [selectedIndex, setSelectedIndex] = useControlledState(
+    index,
+    defaultValue,
+    () => {}
   );
-  const selectedIndex =
-    typeof selectedTabIndex == "number" ? selectedTabIndex : selectedStateIndex;
   return (
     <div
       className={`ac-tabs ${className}`}


### PR DESCRIPTION
Brings to parity with our current `Tabs` component in the arizeweb library which lets you control the selectedTab. Without this, you can't change the selectedTab outside of just clicking the tab itself, example as a callback on a button.

https://github.com/Arize-ai/arize/blob/main/arizeweb/src/app/components/shared/Tabs.tsx#L86-L88