### PR TITLE
feat(icons): Add hard drive outline icon

### DIFF
--- a/src/icon/Icons.tsx
+++ b/src/icon/Icons.tsx
@@ -1355,6 +1355,19 @@ export const HardDriveFilled = () => (
   </svg>
 );
 
+export const HardDriveOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="hard-drive">
+        <rect width="24" height="24" opacity="0" />
+        <path d="M20.79 11.34l-3.34-6.68A3 3 0 0 0 14.76 3H9.24a3 3 0 0 0-2.69 1.66l-3.34 6.68a2 2 0 0 0-.21.9V18a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5.76a2 2 0 0 0-.21-.9zM8.34 5.55a1 1 0 0 1 .9-.55h5.52a1 1 0 0 1 .9.55L18.38 11H5.62zM18 19H6a1 1 0 0 1-1-1v-5h14v5a1 1 0 0 1-1 1z" />
+        <path d="M16 15h-4a1 1 0 0 0 0 2h4a1 1 0 0 0 0-2z" />
+        <circle cx="8" cy="16" r="1" />
+      </g>
+    </g>
+  </svg>
+);
+
 export const Histogram = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">


### PR DESCRIPTION
from: https://akveo.github.io/eva-icons/#/?searchKey=drive&type=outline

dark mode:

![Screenshot 2024-09-05 at 11 02 05 AM](https://github.com/user-attachments/assets/2cda4201-d53b-4b06-889e-3e37f497e567)

light mode:

![Screenshot 2024-09-05 at 11 02 17 AM](https://github.com/user-attachments/assets/a5be2f74-fee6-40ff-bada-a3416c3bdfec)
